### PR TITLE
Handle prefixes & sheets without a number

### DIFF
--- a/lib/stream/xlsx/hyperlink-reader.js
+++ b/lib/stream/xlsx/hyperlink-reader.js
@@ -1,83 +1,85 @@
 const {EventEmitter} = require('events');
 const parseSax = require('../../utils/parse-sax');
+const parseSaxValue = require('../../utils/parse-sax-value');
 
 const Enums = require('../../doc/enums');
 const RelType = require('../../xlsx/rel-type');
 
 class HyperlinkReader extends EventEmitter {
-  constructor({workbook, id, iterator, options}) {
-    super();
+	constructor({workbook, id, iterator, options}) {
+		super();
 
-    this.workbook = workbook;
-    this.id = id;
-    this.iterator = iterator;
-    this.options = options;
-  }
+		this.workbook = workbook;
+		this.id = id;
+		this.iterator = iterator;
+		this.options = options;
+	}
 
-  get count() {
-    return (this.hyperlinks && this.hyperlinks.length) || 0;
-  }
+	get count() {
+		return (this.hyperlinks && this.hyperlinks.length) || 0;
+	}
 
-  each(fn) {
-    return this.hyperlinks.forEach(fn);
-  }
+	each(fn) {
+		return this.hyperlinks.forEach(fn);
+	}
 
-  async read() {
-    const {iterator, options} = this;
-    let emitHyperlinks = false;
-    let hyperlinks = null;
-    switch (options.hyperlinks) {
-      case 'emit':
-        emitHyperlinks = true;
-        break;
-      case 'cache':
-        this.hyperlinks = hyperlinks = {};
-        break;
-      default:
-        break;
-    }
+	async read() {
+		const {iterator, options} = this;
+		let emitHyperlinks = false;
+		let hyperlinks = null;
+		switch (options.hyperlinks) {
+			case 'emit':
+				emitHyperlinks = true;
+				break;
+			case 'cache':
+				this.hyperlinks = hyperlinks = {};
+				break;
+			default:
+				break;
+		}
 
-    if (!emitHyperlinks && !hyperlinks) {
-      this.emit('finished');
-      return;
-    }
+		if (!emitHyperlinks && !hyperlinks) {
+			this.emit('finished');
+			return;
+		}
 
-    try {
-      for await (const events of parseSax(iterator)) {
-        for (const {eventType, value} of events) {
-          if (eventType === 'opentag') {
-            const node = value;
-            if (node.name === 'Relationship') {
-              const rId = node.attributes.Id;
-              switch (node.attributes.Type) {
-                case RelType.Hyperlink:
-                  {
-                    const relationship = {
-                      type: Enums.RelationshipType.Styles,
-                      rId,
-                      target: node.attributes.Target,
-                      targetMode: node.attributes.TargetMode,
-                    };
-                    if (emitHyperlinks) {
-                      this.emit('hyperlink', relationship);
-                    } else {
-                      hyperlinks[relationship.rId] = relationship;
-                    }
-                  }
-                  break;
+		try {
+			for await (const events of parseSax(iterator)) {
+				for (const {eventType, value: saxValue} of events) {
+					const value = parseSaxValue(saxValue);
+					if (eventType === 'opentag') {
+						const node = value;
+						if (node.name === 'Relationship') {
+							const rId = node.attributes.Id;
+							switch (node.attributes.Type) {
+								case RelType.Hyperlink:
+									{
+										const relationship = {
+											type: Enums.RelationshipType.Styles,
+											rId,
+											target: node.attributes.Target,
+											targetMode: node.attributes.TargetMode,
+										};
+										if (emitHyperlinks) {
+											this.emit('hyperlink', relationship);
+										} else {
+											hyperlinks[relationship.rId] = relationship;
+										}
+									}
+									break;
 
-                default:
-                  break;
-              }
-            }
-          }
-        }
-      }
-      this.emit('finished');
-    } catch (error) {
-      this.emit('error', error);
-    }
-  }
+								default:
+									break;
+							}
+						}
+					}
+				}
+			}
+			this.emit('finished');
+		} catch (error) {
+			this.emit('error', error);
+		}
+	}
 }
 
 module.exports = HyperlinkReader;

--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -16,220 +16,220 @@ const HyperlinkReader = require('./hyperlink-reader');
 tmp.setGracefulCleanup();
 
 class WorkbookReader extends EventEmitter {
-  constructor(input, options = {}) {
-    super();
+	constructor(input, options = {}) {
+		super();
 
-    this.input = input;
+		this.input = input;
 
-    this.options = {
-      worksheets: 'emit',
-      sharedStrings: 'cache',
-      hyperlinks: 'ignore',
-      styles: 'ignore',
-      entries: 'ignore',
-      ...options,
-    };
+		this.options = {
+			worksheets: 'emit',
+			sharedStrings: 'cache',
+			hyperlinks: 'ignore',
+			styles: 'ignore',
+			entries: 'ignore',
+			...options,
+		};
 
-    this.styles = new StyleManager();
-    this.styles.init();
+		this.styles = new StyleManager();
+		this.styles.init();
 
-    this.properties = new WorkbookPropertiesManager();
-  }
+		this.properties = new WorkbookPropertiesManager();
+	}
 
-  _getStream(input) {
-    if (input instanceof nodeStream.Readable || input instanceof Readable) {
-      return input;
-    }
-    if (typeof input === 'string') {
-      return fs.createReadStream(input);
-    }
-    throw new Error(`Could not recognise input: ${input}`);
-  }
+	_getStream(input) {
+		if (input instanceof nodeStream.Readable || input instanceof Readable) {
+			return input;
+		}
+		if (typeof input === 'string') {
+			return fs.createReadStream(input);
+		}
+		throw new Error(`Could not recognise input: ${input}`);
+	}
 
-  async read(input, options) {
-    try {
-      for await (const {eventType, value} of this.parse(input, options)) {
-        switch (eventType) {
-          case 'shared-strings':
-            this.emit(eventType, value);
-            break;
-          case 'worksheet':
-            this.emit(eventType, value);
-            await value.read();
-            break;
-          case 'hyperlinks':
-            this.emit(eventType, value);
-            break;
-        }
-      }
-      this.emit('end');
-      this.emit('finished');
-    } catch (error) {
-      this.emit('error', error);
-    }
-  }
+	async read(input, options) {
+		try {
+			for await (const {eventType, value} of this.parse(input, options)) {
+				switch (eventType) {
+					case 'shared-strings':
+						this.emit(eventType, value);
+						break;
+					case 'worksheet':
+						this.emit(eventType, value);
+						await value.read();
+						break;
+					case 'hyperlinks':
+						this.emit(eventType, value);
+						break;
+				}
+			}
+			this.emit('end');
+			this.emit('finished');
+		} catch (error) {
+			this.emit('error', error);
+		}
+	}
 
-  async *[Symbol.asyncIterator]() {
-    for await (const {eventType, value} of this.parse()) {
-      if (eventType === 'worksheet') {
-        yield value;
-      }
-    }
-  }
+	async *[Symbol.asyncIterator]() {
+		for await (const {eventType, value} of this.parse()) {
+			if (eventType === 'worksheet') {
+				yield value;
+			}
+		}
+	}
 
-  async *parse(input, options) {
-    if (options) this.options = options;
-    const stream = (this.stream = this._getStream(input || this.input));
-    const zip = unzip.Parse({forceStream: true});
-    stream.pipe(zip);
+	async *parse(input, options) {
+		if (options) this.options = options;
+		const stream = (this.stream = this._getStream(input || this.input));
+		const zip = unzip.Parse({forceStream: true});
+		stream.pipe(zip);
 
-    // worksheets, deferred for parsing after shared strings reading
-    const waitingWorkSheets = [];
+		// worksheets, deferred for parsing after shared strings reading
+		const waitingWorkSheets = [];
 
-    for await (const entry of iterateStream(zip)) {
-      let match;
-      let sheetNo;
-      switch (entry.path) {
-        case '_rels/.rels':
-        case 'xl/_rels/workbook.xml.rels':
-          break;
-        case 'xl/workbook.xml':
-          await this._parseWorkbook(entry);
-          break;
-        case 'xl/sharedStrings.xml':
-          yield* this._parseSharedStrings(entry);
-          break;
-        case 'xl/styles.xml':
-          await this._parseStyles(entry);
-          break;
-        default:
-          if (entry.path.match(/xl\/worksheets\/sheet\d+[.]xml/)) {
-            match = entry.path.match(/xl\/worksheets\/sheet(\d+)[.]xml/);
-            sheetNo = match[1];
-            if (this.sharedStrings) {
-              yield* this._parseWorksheet(iterateStream(entry), sheetNo);
-            } else {
-              // create temp file for each worksheet
-              await new Promise((resolve, reject) => {
-                tmp.file((err, path, fd, tempFileCleanupCallback) => {
-                  if (err) {
-                    return reject(err);
-                  }
-                  waitingWorkSheets.push({sheetNo, path, tempFileCleanupCallback});
+		for await (const entry of iterateStream(zip)) {
+			let match;
+			let sheetNo;
+			switch (entry.path) {
+				case '_rels/.rels':
+				case 'xl/_rels/workbook.xml.rels':
+					break;
+				case 'xl/workbook.xml':
+					await this._parseWorkbook(entry);
+					break;
+				case 'xl/sharedStrings.xml':
+					yield* this._parseSharedStrings(entry);
+					break;
+				case 'xl/styles.xml':
+					await this._parseStyles(entry);
+					break;
+				default:
+					if (entry.path.match(/xl\/worksheets\/sheet\d*[.]xml/)) {
+						match = entry.path.match(/xl\/worksheets\/sheet(\d*)[.]xml/);
+						sheetNo = match[1] || 1;
+						if (this.sharedStrings) {
+							yield* this._parseWorksheet(iterateStream(entry), sheetNo);
+						} else {
+							// create temp file for each worksheet
+							await new Promise((resolve, reject) => {
+								tmp.file((err, path, fd, tempFileCleanupCallback) => {
+									if (err) {
+										return reject(err);
+									}
+									waitingWorkSheets.push({sheetNo, path, tempFileCleanupCallback});
 
-                  const tempStream = fs.createWriteStream(path);
-                  entry.pipe(tempStream);
-                  return tempStream.on('finish', () => {
-                    return resolve();
-                  });
-                });
-              });
-            }
-          } else if (entry.path.match(/xl\/worksheets\/_rels\/sheet\d+[.]xml.rels/)) {
-            match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d+)[.]xml.rels/);
-            sheetNo = match[1];
-            yield* this._parseHyperlinks(iterateStream(entry), sheetNo);
-          }
-          break;
-      }
-      entry.autodrain();
-    }
+									const tempStream = fs.createWriteStream(path);
+									entry.pipe(tempStream);
+									return tempStream.on('finish', () => {
+										return resolve();
+									});
+								});
+							});
+						}
+					} else if (entry.path.match(/xl\/worksheets\/_rels\/sheet\d*[.]xml.rels/)) {
+						match = entry.path.match(/xl\/worksheets\/_rels\/sheet(\d*)[.]xml.rels/);
+						sheetNo = match[1] || 1;
+						yield* this._parseHyperlinks(iterateStream(entry), sheetNo);
+					}
+					break;
+			}
+			entry.autodrain();
+		}
 
-    for (const {sheetNo, path, tempFileCleanupCallback} of waitingWorkSheets) {
-      let fileStream = fs.createReadStream(path);
-      // TODO: Remove once node v8 is deprecated
-      // Detect and upgrade old fileStreams
-      if (!fileStream[Symbol.asyncIterator]) {
-        fileStream = fileStream.pipe(new PassThrough());
-      }
-      yield* this._parseWorksheet(fileStream, sheetNo);
-      tempFileCleanupCallback();
-    }
-  }
+		for (const {sheetNo, path, tempFileCleanupCallback} of waitingWorkSheets) {
+			let fileStream = fs.createReadStream(path);
+			// TODO: Remove once node v8 is deprecated
+			// Detect and upgrade old fileStreams
+			if (!fileStream[Symbol.asyncIterator]) {
+				fileStream = fileStream.pipe(new PassThrough());
+			}
+			yield* this._parseWorksheet(fileStream, sheetNo);
+			tempFileCleanupCallback();
+		}
+	}
 
-  _emitEntry(payload) {
-    if (this.options.entries === 'emit') {
-      this.emit('entry', payload);
-    }
-  }
+	_emitEntry(payload) {
+		if (this.options.entries === 'emit') {
+			this.emit('entry', payload);
+		}
+	}
 
-  async _parseWorkbook(entry) {
-    this._emitEntry({type: 'workbook'});
-    await this.properties.parseStream(iterateStream(entry));
-  }
+	async _parseWorkbook(entry) {
+		this._emitEntry({type: 'workbook'});
+		await this.properties.parseStream(iterateStream(entry));
+	}
 
-  async *_parseSharedStrings(entry) {
-    this._emitEntry({type: 'shared-strings'});
-    switch (this.options.sharedStrings) {
-      case 'cache':
-        this.sharedStrings = [];
-        break;
-      case 'emit':
-        break;
-      default:
-        return;
-    }
+	async *_parseSharedStrings(entry) {
+		this._emitEntry({type: 'shared-strings'});
+		switch (this.options.sharedStrings) {
+			case 'cache':
+				this.sharedStrings = [];
+				break;
+			case 'emit':
+				break;
+			default:
+				return;
+		}
 
-    let inT = false;
-    let text = null;
-    let index = 0;
-    for await (const events of parseSax(iterateStream(entry))) {
-      for (const {eventType, value} of events) {
-        if (eventType === 'opentag') {
-          const node = value;
-          if (node.name === 't') {
-            text = null;
-            inT = true;
-          }
-        } else if (eventType === 'text') {
-          text = text ? text + value : value;
-        } else if (eventType === 'closetag') {
-          const node = value;
-          if (inT && node.name === 't') {
-            if (this.options.sharedStrings === 'cache') {
-              this.sharedStrings.push(text);
-            } else if (this.options.sharedStrings === 'emit') {
-              yield {index: index++, text};
-            }
-            text = null;
-          }
-        }
-      }
-    }
-  }
+		let inT = false;
+		let text = null;
+		let index = 0;
+		for await (const events of parseSax(iterateStream(entry))) {
+			for (const {eventType, value} of events) {
+				if (eventType === 'opentag') {
+					const node = value;
+					if (node.name === 't') {
+						text = null;
+						inT = true;
+					}
+				} else if (eventType === 'text') {
+					text = text ? text + value : value;
+				} else if (eventType === 'closetag') {
+					const node = value;
+					if (inT && node.name === 't') {
+						if (this.options.sharedStrings === 'cache') {
+							this.sharedStrings.push(text);
+						} else if (this.options.sharedStrings === 'emit') {
+							yield {index: index++, text};
+						}
+						text = null;
+					}
+				}
+			}
+		}
+	}
 
-  async _parseStyles(entry) {
-    this._emitEntry({type: 'styles'});
-    if (this.options.styles === 'cache') {
-      this.styles = new StyleManager();
-      await this.styles.parseStream(iterateStream(entry));
-    }
-  }
+	async _parseStyles(entry) {
+		this._emitEntry({type: 'styles'});
+		if (this.options.styles === 'cache') {
+			this.styles = new StyleManager();
+			await this.styles.parseStream(iterateStream(entry));
+		}
+	}
 
-  *_parseWorksheet(iterator, sheetNo) {
-    this._emitEntry({type: 'worksheet', id: sheetNo});
-    const worksheetReader = new WorksheetReader({workbook: this, id: sheetNo, iterator, options: this.options});
-    if (this.options.worksheets === 'emit') {
-      yield {eventType: 'worksheet', value: worksheetReader};
-    }
-  }
+	*_parseWorksheet(iterator, sheetNo) {
+		this._emitEntry({type: 'worksheet', id: sheetNo});
+		const worksheetReader = new WorksheetReader({workbook: this, id: sheetNo, iterator, options: this.options});
+		if (this.options.worksheets === 'emit') {
+			yield {eventType: 'worksheet', value: worksheetReader};
+		}
+	}
 
-  *_parseHyperlinks(iterator, sheetNo) {
-    this._emitEntry({type: 'hyperlinks', id: sheetNo});
-    const hyperlinksReader = new HyperlinkReader({workbook: this, id: sheetNo, iterator, options: this.options});
-    if (this.options.hyperlinks === 'emit') {
-      yield {eventType: 'hyperlinks', value: hyperlinksReader};
-    }
-  }
+	*_parseHyperlinks(iterator, sheetNo) {
+		this._emitEntry({type: 'hyperlinks', id: sheetNo});
+		const hyperlinksReader = new HyperlinkReader({workbook: this, id: sheetNo, iterator, options: this.options});
+		if (this.options.hyperlinks === 'emit') {
+			yield {eventType: 'hyperlinks', value: hyperlinksReader};
+		}
+	}
 }
 
 // for reference - these are the valid values for options
 WorkbookReader.Options = {
-  worksheets: ['emit', 'ignore'],
-  sharedStrings: ['cache', 'emit', 'ignore'],
-  hyperlinks: ['cache', 'emit', 'ignore'],
-  styles: ['cache', 'ignore'],
-  entries: ['emit', 'ignore'],
+	worksheets: ['emit', 'ignore'],
+	sharedStrings: ['cache', 'emit', 'ignore'],
+	hyperlinks: ['cache', 'emit', 'ignore'],
+	styles: ['cache', 'ignore'],
+	entries: ['emit', 'ignore'],
 };
 
 module.exports = WorkbookReader;

--- a/lib/stream/xlsx/workbook-reader.js
+++ b/lib/stream/xlsx/workbook-reader.js
@@ -6,6 +6,7 @@ const unzip = require('unzipper');
 const tmp = require('tmp');
 const iterateStream = require('../../utils/iterate-stream');
 const parseSax = require('../../utils/parse-sax');
+const parseSaxValue = require('../../utils/parse-sax-value');
 
 const StyleManager = require('../../xlsx/xform/style/styles-xform');
 const WorkbookPropertiesManager = require('../../xlsx/xform/book/workbook-properties-xform');
@@ -174,7 +175,8 @@ class WorkbookReader extends EventEmitter {
 		let text = null;
 		let index = 0;
 		for await (const events of parseSax(iterateStream(entry))) {
-			for (const {eventType, value} of events) {
+			for (const {eventType, value: saxValue} of events) {
+				const value = parseSaxValue(saxValue);
 				if (eventType === 'opentag') {
 					const node = value;
 					if (node.name === 't') {

--- a/lib/stream/xlsx/worksheet-reader.js
+++ b/lib/stream/xlsx/worksheet-reader.js
@@ -1,5 +1,6 @@
 const {EventEmitter} = require('events');
 const parseSax = require('../../utils/parse-sax');
+const parseSaxValue = require('../../utils/parse-sax-value');
 
 const _ = require('../../utils/under-dash');
 const utils = require('../../utils/utils');
@@ -10,355 +11,359 @@ const Row = require('../../doc/row');
 const Column = require('../../doc/column');
 
 class WorksheetReader extends EventEmitter {
-  constructor({workbook, id, iterator, options}) {
-    super();
+	constructor({workbook, id, iterator, options}) {
+		super();
 
-    this.workbook = workbook;
-    this.id = id;
-    this.iterator = iterator;
-    this.options = options || {};
+		this.workbook = workbook;
+		this.id = id;
+		this.iterator = iterator;
+		this.options = options || {};
 
-    // and a name
-    this.name = `Sheet${this.id}`;
+		// and a name
+		this.name = `Sheet${this.id}`;
 
-    // column definitions
-    this._columns = null;
-    this._keys = {};
+		// column definitions
+		this._columns = null;
+		this._keys = {};
 
-    // keep a record of dimensions
-    this._dimensions = new Dimensions();
-  }
+		// keep a record of dimensions
+		this._dimensions = new Dimensions();
+	}
 
-  // destroy - not a valid operation for a streaming writer
-  // even though some streamers might be able to, it's a bad idea.
-  destroy() {
-    throw new Error('Invalid Operation: destroy');
-  }
+	// destroy - not a valid operation for a streaming writer
+	// even though some streamers might be able to, it's a bad idea.
+	destroy() {
+		throw new Error('Invalid Operation: destroy');
+	}
 
-  // return the current dimensions of the writer
-  get dimensions() {
-    return this._dimensions;
-  }
+	// return the current dimensions of the writer
+	get dimensions() {
+		return this._dimensions;
+	}
 
-  // =========================================================================
-  // Columns
+	// =========================================================================
+	// Columns
 
-  // get the current columns array.
-  get columns() {
-    return this._columns;
-  }
+	// get the current columns array.
+	get columns() {
+		return this._columns;
+	}
 
-  // get a single column by col number. If it doesn't exist, it and any gaps before it
-  // are created.
-  getColumn(c) {
-    if (typeof c === 'string') {
-      // if it matches a key'd column, return that
-      const col = this._keys[c];
-      if (col) {
-        return col;
-      }
+	// get a single column by col number. If it doesn't exist, it and any gaps before it
+	// are created.
+	getColumn(c) {
+		if (typeof c === 'string') {
+			// if it matches a key'd column, return that
+			const col = this._keys[c];
+			if (col) {
+				return col;
+			}
 
-      // otherise, assume letter
-      c = colCache.l2n(c);
-    }
-    if (!this._columns) {
-      this._columns = [];
-    }
-    if (c > this._columns.length) {
-      let n = this._columns.length + 1;
-      while (n <= c) {
-        this._columns.push(new Column(this, n++));
-      }
-    }
-    return this._columns[c - 1];
-  }
+			// otherise, assume letter
+			c = colCache.l2n(c);
+		}
+		if (!this._columns) {
+			this._columns = [];
+		}
+		if (c > this._columns.length) {
+			let n = this._columns.length + 1;
+			while (n <= c) {
+				this._columns.push(new Column(this, n++));
+			}
+		}
+		return this._columns[c - 1];
+	}
 
-  getColumnKey(key) {
-    return this._keys[key];
-  }
+	getColumnKey(key) {
+		return this._keys[key];
+	}
 
-  setColumnKey(key, value) {
-    this._keys[key] = value;
-  }
+	setColumnKey(key, value) {
+		this._keys[key] = value;
+	}
 
-  deleteColumnKey(key) {
-    delete this._keys[key];
-  }
+	deleteColumnKey(key) {
+		delete this._keys[key];
+	}
 
-  eachColumnKey(f) {
-    _.each(this._keys, f);
-  }
+	eachColumnKey(f) {
+		_.each(this._keys, f);
+	}
 
-  async read() {
-    try {
-      for await (const events of this.parse()) {
-        for (const {eventType, value} of events) {
-          this.emit(eventType, value);
-        }
-      }
-      this.emit('finished');
-    } catch (error) {
-      this.emit('error', error);
-    }
-  }
+	async read() {
+		try {
+			for await (const events of this.parse()) {
+				for (const {eventType, value} of events) {
+					this.emit(eventType, value);
+				}
+			}
+			this.emit('finished');
+		} catch (error) {
+			this.emit('error', error);
+		}
+	}
 
-  async *[Symbol.asyncIterator]() {
-    for await (const events of this.parse()) {
-      for (const {eventType, value} of events) {
-        if (eventType === 'row') {
-          yield value;
-        }
-      }
-    }
-  }
+	async *[Symbol.asyncIterator]() {
+		for await (const events of this.parse()) {
+			for (const {eventType, value} of events) {
+				if (eventType === 'row') {
+					yield value;
+				}
+			}
+		}
+	}
 
-  async *parse() {
-    const {iterator, options} = this;
-    let emitSheet = false;
-    let emitHyperlinks = false;
-    let hyperlinks = null;
-    switch (options.worksheets) {
-      case 'emit':
-        emitSheet = true;
-        break;
-      case 'prep':
-        break;
-      default:
-        break;
-    }
-    switch (options.hyperlinks) {
-      case 'emit':
-        emitHyperlinks = true;
-        break;
-      case 'cache':
-        this.hyperlinks = hyperlinks = {};
-        break;
-      default:
-        break;
-    }
-    if (!emitSheet && !emitHyperlinks && !hyperlinks) {
-      return;
-    }
+	async *parse() {
+		const {iterator, options} = this;
+		let emitSheet = false;
+		let emitHyperlinks = false;
+		let hyperlinks = null;
+		switch (options.worksheets) {
+			case 'emit':
+				emitSheet = true;
+				break;
+			case 'prep':
+				break;
+			default:
+				break;
+		}
+		switch (options.hyperlinks) {
+			case 'emit':
+				emitHyperlinks = true;
+				break;
+			case 'cache':
+				this.hyperlinks = hyperlinks = {};
+				break;
+			default:
+				break;
+		}
+		if (!emitSheet && !emitHyperlinks && !hyperlinks) {
+			return;
+		}
 
-    // references
-    const {sharedStrings, styles, properties} = this.workbook;
+		// references
+		const {sharedStrings, styles, properties} = this.workbook;
 
-    // xml position
-    let inCols = false;
-    let inRows = false;
-    let inHyperlinks = false;
+		// xml position
+		let inCols = false;
+		let inRows = false;
+		let inHyperlinks = false;
 
-    // parse state
-    let cols = null;
-    let row = null;
-    let c = null;
-    let current = null;
-    for await (const events of parseSax(iterator)) {
-      const worksheetEvents = [];
-      for (const {eventType, value} of events) {
-        if (eventType === 'opentag') {
-          const node = value;
-          if (emitSheet) {
-            switch (node.name) {
-              case 'cols':
-                inCols = true;
-                cols = [];
-                break;
-              case 'sheetData':
-                inRows = true;
-                break;
+		// parse state
+		let cols = null;
+		let row = null;
+		let c = null;
+		let current = null;
+		for await (const events of parseSax(iterator)) {
+			const worksheetEvents = [];
+			for (const {eventType, value: saxValue} of events) {
+				const value = parseSaxValue(saxValue);
+				if (eventType === 'opentag') {
+					const node = value;
+					if (emitSheet) {
+						switch (node.name) {
+							case 'cols':
+								inCols = true;
+								cols = [];
+								break;
+							case 'sheetData':
+								inRows = true;
+								break;
 
-              case 'col':
-                if (inCols) {
-                  cols.push({
-                    min: parseInt(node.attributes.min, 10),
-                    max: parseInt(node.attributes.max, 10),
-                    width: parseFloat(node.attributes.width),
-                    styleId: parseInt(node.attributes.style || '0', 10),
-                  });
-                }
-                break;
+							case 'col':
+								if (inCols) {
+									cols.push({
+										min: parseInt(node.attributes.min, 10),
+										max: parseInt(node.attributes.max, 10),
+										width: parseFloat(node.attributes.width),
+										styleId: parseInt(node.attributes.style || '0', 10),
+									});
+								}
+								break;
 
-              case 'row':
-                if (inRows) {
-                  const r = parseInt(node.attributes.r, 10);
-                  row = new Row(this, r);
-                  if (node.attributes.ht) {
-                    row.height = parseFloat(node.attributes.ht);
-                  }
-                  if (node.attributes.s) {
-                    const styleId = parseInt(node.attributes.s, 10);
-                    const style = styles.getStyleModel(styleId);
-                    if (style) {
-                      row.style = style;
-                    }
-                  }
-                }
-                break;
-              case 'c':
-                if (row) {
-                  c = {
-                    ref: node.attributes.r,
-                    s: parseInt(node.attributes.s, 10),
-                    t: node.attributes.t,
-                  };
-                }
-                break;
-              case 'f':
-                if (c) {
-                  current = c.f = {text: ''};
-                }
-                break;
-              case 'v':
-                if (c) {
-                  current = c.v = {text: ''};
-                }
-                break;
-              case 'mergeCell':
-                break;
-              default:
-                break;
-            }
-          }
+							case 'row':
+								if (inRows) {
+									const r = parseInt(node.attributes.r, 10);
+									row = new Row(this, r);
+									if (node.attributes.ht) {
+										row.height = parseFloat(node.attributes.ht);
+									}
+									if (node.attributes.s) {
+										const styleId = parseInt(node.attributes.s, 10);
+										const style = styles.getStyleModel(styleId);
+										if (style) {
+											row.style = style;
+										}
+									}
+								}
+								break;
+							case 'c':
+								if (row) {
+									c = {
+										ref: node.attributes.r,
+										s: parseInt(node.attributes.s, 10),
+										t: node.attributes.t,
+									};
+								}
+								break;
+							case 'f':
+								if (c) {
+									current = c.f = {text: ''};
+								}
+								break;
+							case 'v':
+								if (c) {
+									current = c.v = {text: ''};
+								}
+								break;
+							case 'mergeCell':
+								break;
+							default:
+								break;
+						}
+					}
 
-          // =================================================================
-          //
-          if (emitHyperlinks || hyperlinks) {
-            switch (node.name) {
-              case 'hyperlinks':
-                inHyperlinks = true;
-                break;
-              case 'hyperlink':
-                if (inHyperlinks) {
-                  const hyperlink = {
-                    ref: node.attributes.ref,
-                    rId: node.attributes['r:id'],
-                  };
-                  if (emitHyperlinks) {
-                    worksheetEvents.push({eventType: 'hyperlink', value: hyperlink});
-                  } else {
-                    hyperlinks[hyperlink.ref] = hyperlink;
-                  }
-                }
-                break;
-              default:
-                break;
-            }
-          }
-        } else if (eventType === 'text') {
-          // only text data is for sheet values
-          if (emitSheet) {
-            if (current) {
-              current.text += value;
-            }
-          }
-        } else if (eventType === 'closetag') {
-          const node = value;
-          if (emitSheet) {
-            switch (node.name) {
-              case 'cols':
-                inCols = false;
-                this._columns = Column.fromModel(cols);
-                break;
-              case 'sheetData':
-                inRows = false;
-                break;
+					// =================================================================
+					//
+					if (emitHyperlinks || hyperlinks) {
+						switch (node.name) {
+							case 'hyperlinks':
+								inHyperlinks = true;
+								break;
+							case 'hyperlink':
+								if (inHyperlinks) {
+									const hyperlink = {
+										ref: node.attributes.ref,
+										rId: node.attributes['r:id'],
+									};
+									if (emitHyperlinks) {
+										worksheetEvents.push({eventType: 'hyperlink', value: hyperlink});
+									} else {
+										hyperlinks[hyperlink.ref] = hyperlink;
+									}
+								}
+								break;
+							default:
+								break;
+						}
+					}
+				} else if (eventType === 'text') {
+					// only text data is for sheet values
+					if (emitSheet) {
+						if (current) {
+							current.text += value;
+						}
+					}
+				} else if (eventType === 'closetag') {
+					const node = value;
+					if (emitSheet) {
+						switch (node.name) {
+							case 'cols':
+								inCols = false;
+								this._columns = Column.fromModel(cols);
+								break;
+							case 'sheetData':
+								inRows = false;
+								break;
 
-              case 'row':
-                this._dimensions.expandRow(row);
-                worksheetEvents.push({eventType: 'row', value: row});
-                row = null;
-                break;
+							case 'row':
+								this._dimensions.expandRow(row);
+								worksheetEvents.push({eventType: 'row', value: row});
+								row = null;
+								break;
 
-              case 'c':
-                if (row && c) {
-                  const address = colCache.decodeAddress(c.ref);
-                  const cell = row.getCell(address.col);
-                  if (c.s) {
-                    const style = styles.getStyleModel(c.s);
-                    if (style) {
-                      cell.style = style;
-                    }
-                  }
+							case 'c':
+								if (row && c) {
+									const address = colCache.decodeAddress(c.ref);
+									const cell = row.getCell(address.col);
+									if (c.s) {
+										const style = styles.getStyleModel(c.s);
+										if (style) {
+											cell.style = style;
+										}
+									}
 
-                  if (c.f) {
-                    const cellValue = {
-                      formula: c.f.text,
-                    };
-                    if (c.v) {
-                      if (c.t === 'str') {
-                        cellValue.result = utils.xmlDecode(c.v.text);
-                      } else {
-                        cellValue.result = parseFloat(c.v.text);
-                      }
-                    }
-                    cell.value = cellValue;
-                  } else if (c.v) {
-                    switch (c.t) {
-                      case 's': {
-                        const index = parseInt(c.v.text, 10);
-                        if (sharedStrings) {
-                          cell.value = sharedStrings[index];
-                        } else {
-                          cell.value = {
-                            sharedString: index,
-                          };
-                        }
-                        break;
-                      }
+									if (c.f) {
+										const cellValue = {
+											formula: c.f.text,
+										};
+										if (c.v) {
+											if (c.t === 'str') {
+												cellValue.result = utils.xmlDecode(c.v.text);
+											} else {
+												cellValue.result = parseFloat(c.v.text);
+											}
+										}
+										cell.value = cellValue;
+									} else if (c.v) {
+										switch (c.t) {
+											case 's': {
+												const index = parseInt(c.v.text, 10);
+												if (sharedStrings) {
+													cell.value = sharedStrings[index];
+												} else {
+													cell.value = {
+														sharedString: index,
+													};
+												}
+												break;
+											}
 
-                      case 'str':
-                        cell.value = utils.xmlDecode(c.v.text);
-                        break;
+											case 'str':
+												cell.value = utils.xmlDecode(c.v.text);
+												break;
 
-                      case 'e':
-                        cell.value = {error: c.v.text};
-                        break;
+											case 'e':
+												cell.value = {error: c.v.text};
+												break;
 
-                      case 'b':
-                        cell.value = parseInt(c.v.text, 10) !== 0;
-                        break;
+											case 'b':
+												cell.value = parseInt(c.v.text, 10) !== 0;
+												break;
 
-                      default:
-                        if (utils.isDateFmt(cell.numFmt)) {
-                          cell.value = utils.excelToDate(parseFloat(c.v.text), properties.model && properties.model.date1904);
-                        } else {
-                          cell.value = parseFloat(c.v.text);
-                        }
-                        break;
-                    }
-                  }
-                  if (hyperlinks) {
-                    const hyperlink = hyperlinks[c.ref];
-                    if (hyperlink) {
-                      cell.text = cell.value;
-                      cell.value = undefined;
-                      cell.hyperlink = hyperlink;
-                    }
-                  }
-                  c = null;
-                }
-                break;
-              default:
-                break;
-            }
-          }
-          if (emitHyperlinks || hyperlinks) {
-            switch (node.name) {
-              case 'hyperlinks':
-                inHyperlinks = false;
-                break;
-              default:
-                break;
-            }
-          }
-        }
-      }
-      if (worksheetEvents.length > 0) {
-        yield worksheetEvents;
-      }
-    }
-  }
+											default:
+												if (utils.isDateFmt(cell.numFmt)) {
+													cell.value = utils.excelToDate(
+														parseFloat(c.v.text),
+														properties.model && properties.model.date1904
+													);
+												} else {
+													cell.value = parseFloat(c.v.text);
+												}
+												break;
+										}
+									}
+									if (hyperlinks) {
+										const hyperlink = hyperlinks[c.ref];
+										if (hyperlink) {
+											cell.text = cell.value;
+											cell.value = undefined;
+											cell.hyperlink = hyperlink;
+										}
+									}
+									c = null;
+								}
+								break;
+							default:
+								break;
+						}
+					}
+					if (emitHyperlinks || hyperlinks) {
+						switch (node.name) {
+							case 'hyperlinks':
+								inHyperlinks = false;
+								break;
+							default:
+								break;
+						}
+					}
+				}
+			}
+			if (worksheetEvents.length > 0) {
+				yield worksheetEvents;
+			}
+		}
+	}
 }
 
 module.exports = WorksheetReader;

--- a/lib/utils/parse-sax-value.js
+++ b/lib/utils/parse-sax-value.js
@@ -1,0 +1,7 @@
+module.exports = function(value) {
+	if (value.name) {
+		// Remove prefixes
+		value.name = value.name.replace(/^\w+:/, '');
+	}
+	return value;
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Two issues attempted to be fixed here:

**Incorrect sheet reference**
Typically a workbook XML should contain references to all the sheets inside a workbook. The package used for the fileprocessor expects that these sheets all have a number, but in this file the sheet ID is just sheet, which seems incorrect. Opening in Excel and resaving corrects the XML.

**Use of a namespace**
On top of this, the XML seems to provide a namespace which get prefixed to all the nodes. Again opening in Excel and resaving corrects the XML, but for the package this results in there appearing to be no data. 

**Screenshot of the issues**
![image](https://user-images.githubusercontent.com/26712915/89129444-549ef100-d4f5-11ea-9b80-1f6339bcace2.png)